### PR TITLE
Add dual logging functionality to YCSB control script

### DIFF
--- a/bin/bindings.properties
+++ b/bin/bindings.properties
@@ -26,89 +26,188 @@
 # - The java_class_path should point to the Java class that implements the YCSB client for the database.
 
 # Key-Value Stores
-memcached:site.ycsb.db.MemcachedClient            # Memcached client
-redis:site.ycsb.db.RedisClient                    # Redis client
+# Memcached client
+memcached:site.ycsb.db.MemcachedClient            
+
+# Redis client
+redis:site.ycsb.db.RedisClient                    
 
 # Document Stores
-mongodb:site.ycsb.db.MongoDbClient                # MongoDB client
-couchbase:site.ycsb.db.CouchbaseClient            # Couchbase client
+# MongoDB client
+mongodb:site.ycsb.db.MongoDbClient                
+
+# Couchbase client
+couchbase:site.ycsb.db.CouchbaseClient            
 
 # Column Stores
-cassandra-cql:site.ycsb.db.CassandraCQLClient     # Cassandra CQL client
-hbase1:site.ycsb.db.hbase1.HBaseClient1           # HBase version 1 client
+# Cassandra CQL client
+cassandra-cql:site.ycsb.db.CassandraCQLClient     
+
+# HBase version 1 client
+hbase1:site.ycsb.db.hbase1.HBaseClient1           
 
 # Graph Databases
-arangodb:site.ycsb.db.arangodb.ArangoDBClient     # ArangoDB client
-orientdb:site.ycsb.db.OrientDBClient              # OrientDB client
+# ArangoDB client
+arangodb:site.ycsb.db.arangodb.ArangoDBClient     
+
+# OrientDB client
+orientdb:site.ycsb.db.OrientDBClient              
 
 # NewSQL Databases
-voltdb:site.ycsb.db.voltdb.VoltClient4            # VoltDB client
-googlebigtable:site.ycsb.db.GoogleBigtableClient  # Google Bigtable client
+# VoltDB client
+voltdb:site.ycsb.db.voltdb.VoltClient4            
+
+# Google Bigtable client
+googlebigtable:site.ycsb.db.GoogleBigtableClient  
 
 # Wide-Column Stores
-scylla:site.ycsb.db.scylla.ScyllaCQLClient        # ScyllaDB client, compatible with Cassandra
+# ScyllaDB client, compatible with Cassandra
+scylla:site.ycsb.db.scylla.ScyllaCQLClient        
 
 # Search Engines
-elasticsearch:site.ycsb.db.ElasticsearchClient    # Elasticsearch client
+# Elasticsearch client
+elasticsearch:site.ycsb.db.ElasticsearchClient    
+
+# Elasticsearch version 7 client
 elasticsearch7:site.ycsb.db.elasticsearch7.ElasticsearchClient
+
+# Elasticsearch version 7 REST client
 elasticsearch7-rest:site.ycsb.db.elasticsearch7.ElasticsearchRestClient
-# Time Series Databases
-basicts:site.ycsb.BasicTSDB                       # Basic Time Series DB client
 
 # Multi-Model Databases
-foundationdb:site.ycsb.db.foundationdb.FoundationDBClient  # FoundationDB client
+# FoundationDB client
+foundationdb:site.ycsb.db.foundationdb.FoundationDBClient  
 
 # Relational Databases
-jdbc:site.ycsb.db.JdbcDBClient                    # Generic JDBC client
+# Generic JDBC client
+jdbc:site.ycsb.db.JdbcDBClient                    
 
 # NoSQL Databases
-dynamodb:site.ycsb.db.DynamoDBClient              # Amazon DynamoDB client
-nosqldb:site.ycsb.db.NoSqlDbClient                # Oracle NoSQL database client
+# Amazon DynamoDB client
+dynamodb:site.ycsb.db.DynamoDBClient              
+
+# Oracle NoSQL database client
+nosqldb:site.ycsb.db.NoSqlDbClient                
 
 # Cloud Databases
-azurecosmos:site.ycsb.db.AzureCosmosClient        # Azure Cosmos DB client
-googledatastore:site.ycsb.db.GoogleDatastoreClient# Google Cloud Datastore client
+# Azure Cosmos DB client
+azurecosmos:site.ycsb.db.AzureCosmosClient        
+
+# Google Cloud Datastore client
+googledatastore:site.ycsb.db.GoogleDatastoreClient
 
 # In-Memory Data Grids
-ignite:site.ycsb.db.ignite.IgniteClient           # Apache Ignite client
-ignite-sql:site.ycsb.db.ignite.IgniteSqlClient    # Apache Ignite SQL client
+# Apache Ignite client
+ignite:site.ycsb.db.ignite.IgniteClient           
+
+# Apache Ignite SQL client
+ignite-sql:site.ycsb.db.ignite.IgniteSqlClient    
 
 # Object Stores
-s3:site.ycsb.db.S3Client                          # Amazon S3 client
+# Amazon S3 client
+s3:site.ycsb.db.S3Client                          
 
 # Distributed File Systems
-crail:site.ycsb.db.crail.CrailClient              # Apache Crail (Incubating) client
+# Apache Crail (Incubating) client
+crail:site.ycsb.db.crail.CrailClient              
 
 # Other Storage Models
-rados:site.ycsb.db.RadosClient                    # Ceph RADOS client
+# Ceph RADOS client
+rados:site.ycsb.db.RadosClient                    
 
 # Time Series Databases
-solr7:site.ycsb.db.solr7.SolrClient               # Apache Solr 7 client
-tarantool:site.ycsb.db.TarantoolClient            # Tarantool client
+# Apache Solr 7 client
+solr7:site.ycsb.db.solr7.SolrClient               
+
+# Tarantool client
+tarantool:site.ycsb.db.TarantoolClient            
 
 # Blockchain Databases
-tablestore:site.ycsb.db.tablestore.TableStoreClient # Alibaba Cloud TableStore client
-voltdb:site.ycsb.db.voltdb.VoltClient4             # VoltDB client
+# Alibaba Cloud TableStore client
+tablestore:site.ycsb.db.tablestore.TableStoreClient
+
+# VoltDB client
+voltdb:site.ycsb.db.voltdb.VoltClient4            
 
 # Distributed Key-Value Stores
-infinispan:site.ycsb.db.InfinispanClient          # Infinispan client
-infinispan-cs:site.ycsb.db.InfinispanRemoteClient # Infinispan client for remote connections
+# Infinispan client
+infinispan:site.ycsb.db.InfinispanClient          
+
+# Infinispan client for remote connections
+infinispan-cs:site.ycsb.db.InfinispanRemoteClient 
 
 # Additional Key-Value Stores
-riak:site.ycsb.db.riak.RiakKVClient               # Riak KV client
-rocksdb:site.ycsb.db.rocksdb.RocksDBClient        # RocksDB client
+# Riak KV client
+riak:site.ycsb.db.riak.RiakKVClient               
+
+# RocksDB client
+rocksdb:site.ycsb.db.rocksdb.RocksDBClient        
 
 # Experimental or Less Commonly Used Databases
-kudu:site.ycsb.db.KuduYCSBClient                  # Apache Kudu client
-zookeeper:site.ycsb.db.zookeeper.ZKClient         # Apache ZooKeeper client
+# Apache Kudu client
+kudu:site.ycsb.db.KuduYCSBClient                  
+
+# Apache ZooKeeper client
+zookeeper:site.ycsb.db.zookeeper.ZKClient         
 
 # Legacy or Deprecated Bindings (Use with caution as these may not be supported in future versions)
-hbase14:site.ycsb.db.hbase14.HBaseClient14        # HBase 1.4 client
-cassandra2:site.ycsb.db.CassandraCQLClient        # Legacy Cassandra 2.x CQL client
-couchbase2:site.ycsb.db.couchbase2.Couchbase2Client # Legacy Couchbase 2.x client
+# HBase 1.4 client
+hbase14:site.ycsb.db.hbase14.HBaseClient14        
 
+# Legacy Cassandra 2.x CQL client
+cassandra2:site.ycsb.db.CassandraCQLClient        
+
+# Legacy Couchbase 2.x client
+couchbase2:site.ycsb.db.couchbase2.Couchbase2Client
+
+# Redis Modules
+# RediSearch client
 redisearch:site.ycsb.db.RediSearchClient
+
+# Redis JSON client
 redisjson2:site.ycsb.db.RedisJSONClient
+
+# Additional Document Stores
+# ArangoDB client, version 3
+arangodb3:site.ycsb.db.arangodb.ArangoDBClient   
+
+# Cloud NoSQL Databases
+# Azure Table Storage client
+azuretablestorage:site.ycsb.db.azuretablestorage.AzureClient
+
+# Distributed Data Grids
+# Apache Geode client
+geode:site.ycsb.db.GeodeClient                   
+
+# Distributed Key-Value Stores
+# Apache Accumulo 1.9 client
+accumulo1.9:site.ycsb.db.accumulo.AccumuloClient 
+
+# Asynchronous HBase client
+asynchbase:site.ycsb.db.AsyncHBaseClient         
+
+# Distributed Multimodel Databases
+# Google Cloud Spanner client
+cloudspanner:site.ycsb.db.cloudspanner.CloudSpannerClient
+
+# Key-Value/Timeseries Hybrid
+# Basic DB client
+basic:site.ycsb.BasicDB                          
+
+# Basic Time Series DB client
+basicts:site.ycsb.BasicTSDB                      
+
+# Search and Analytic Engines
+# Elasticsearch version 5 client
+elasticsearch5:site.ycsb.db.elasticsearch5.ElasticsearchClient       
+
+# Elasticsearch version 5 REST client
+elasticsearch5-rest:site.ycsb.db.elasticsearch5.ElasticsearchRestClient 
+
+# Additional Column Stores
+# HBase version 2 client
+hbase2:site.ycsb.db.hbase2.HBaseClient2  
+
 # New Entries
 # Ensure you document any new database bindings here and also ensure they are tested thoroughly.
 

--- a/bin/ycsb.sh
+++ b/bin/ycsb.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2012 - 2024 YCSB contributors. All rights reserved.
+# Copyright (c) 2012 - 2016 YCSB contributors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you
 # may not use this file except in compliance with the License. You
@@ -23,12 +23,12 @@
 #   Do not set the variables in this script. Instead put them into a script
 #   setenv.sh in YCSB_HOME/bin to keep your customizations separate.
 #
-#   YCSB_HOME       (Optional) YCSB installation directory. If not set
+#   YCSB_HOME       (Optional) YCSB installation directory.  If not set
 #                   this script will use the parent directory of where this
 #                   script is run from.
 #
 #   JAVA_HOME       (Optional) Must point at your Java Development Kit
-#                   installation. If empty, this script tries use the
+#                   installation.  If empty, this script tries use the
 #                   available java executable.
 #
 #   JAVA_OPTS       (Optional) Java runtime options used when any command
@@ -49,58 +49,55 @@ esac
 SCRIPT_DIR=$(dirname "$0" 2>/dev/null)
 
 # Only set YCSB_HOME if not already set
-: "${YCSB_HOME:=$(cd "$SCRIPT_DIR/.." && pwd)}"
+[ -z "$YCSB_HOME" ] && YCSB_HOME=$(cd "$SCRIPT_DIR/.." || exit; pwd)
 
 # Ensure that any extra CLASSPATH variables are set via setenv.sh
 CLASSPATH=
 
 # Pull in customization options
 if [ -r "$YCSB_HOME/bin/setenv.sh" ]; then
+  # Shellcheck wants a source, but this directive only runs if available
+  #   So, tell shellcheck to ignore
   # shellcheck source=/dev/null
   . "$YCSB_HOME/bin/setenv.sh"
 fi
 
 # Attempt to find the available JAVA, if JAVA_HOME not set
 if [ -z "$JAVA_HOME" ]; then
-  JAVA_PATH=$(command -v java 2>/dev/null)
-  if [ -n "$JAVA_PATH" ]; then
-    JAVA_HOME=$(dirname "$(dirname "$JAVA_PATH")")
+  JAVA_PATH=$(which java 2>/dev/null)
+  if [ "x$JAVA_PATH" != "x" ]; then
+    JAVA_HOME=$(dirname "$(dirname "$JAVA_PATH" 2>/dev/null)")
   fi
 fi
 
 # If JAVA_HOME still not set, error
 if [ -z "$JAVA_HOME" ]; then
-  echo "[ERROR] Java executable not found. Exiting." >&2
-  exit 1
+  echo "[ERROR] Java executable not found. Exiting."
+  exit 1;
 fi
 
 # Determine YCSB command argument
-case "$1" in
-  load)
-    YCSB_COMMAND=-load
-    YCSB_CLASS=site.ycsb.Client
-    ;;
-  run)
-    YCSB_COMMAND=-t
-    YCSB_CLASS=site.ycsb.Client
-    ;;
-  shell)
-    YCSB_COMMAND=
-    YCSB_CLASS=site.ycsb.CommandLine
-    ;;
-  *)
-    echo "[ERROR] Found unknown command '$1'" >&2
-    echo "[ERROR] Expected one of 'load', 'run', or 'shell'. Exiting." >&2
-    exit 1
-    ;;
-esac
+if [ "load" = "$1" ] ; then
+  YCSB_COMMAND=-load
+  YCSB_CLASS=site.ycsb.Client
+elif [ "run" = "$1" ] ; then
+  YCSB_COMMAND=-t
+  YCSB_CLASS=site.ycsb.Client
+elif [ "shell" = "$1" ] ; then
+  YCSB_COMMAND=
+  YCSB_CLASS=site.ycsb.CommandLine
+else
+  echo "[ERROR] Found unknown command '$1'"
+  echo "[ERROR] Expected one of 'load', 'run', or 'shell'. Exiting."
+  exit 1;
+fi
 
 # Find binding information
 BINDING_LINE=$(grep "^$2:" "$YCSB_HOME/bin/bindings.properties" -m 1)
 
-if [ -z "$BINDING_LINE" ]; then
-  echo "[ERROR] The specified binding '$2' was not found. Exiting." >&2
-  exit 1
+if [ -z "$BINDING_LINE" ] ; then
+  echo "[ERROR] The specified binding '$2' was not found. Exiting."
+  exit 1;
 fi
 
 # Get binding name and class
@@ -108,117 +105,166 @@ BINDING_NAME=$(echo "$BINDING_LINE" | cut -d':' -f1)
 BINDING_CLASS=$(echo "$BINDING_LINE" | cut -d':' -f2)
 
 # Some bindings have multiple versions that are managed in the same directory.
-# They are noted with a '-' after the binding name.
-# (e.g. cassandra-7 & cassandra-8)
+#   They are noted with a '-' after the binding name.
+#   (e.g. cassandra-7 & cassandra-8)
 BINDING_DIR=$(echo "$BINDING_NAME" | cut -d'-' -f1)
 
 # The 'basic' binding is core functionality
-if [ "$BINDING_NAME" = "basic" ]; then
+if [ "$BINDING_NAME" = "basic" ] ; then
   BINDING_DIR=core
 fi
 
 # For Cygwin, ensure paths are in UNIX format before anything is touched
-if "$CYGWIN"; then
-  JAVA_HOME=$(cygpath --unix "$JAVA_HOME")
-  CLASSPATH=$(cygpath --path --unix "$CLASSPATH")
+if $CYGWIN; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=$(cygpath --unix "$JAVA_HOME")
+  [ -n "$CLASSPATH" ] && CLASSPATH=$(cygpath --path --unix "$CLASSPATH")
 fi
 
 # Check if source checkout, or release distribution
 DISTRIBUTION=true
 if [ -r "$YCSB_HOME/pom.xml" ]; then
-  DISTRIBUTION=false
+  DISTRIBUTION=false;
 fi
 
 # Add Top level conf to classpath
-CLASSPATH="$CLASSPATH:$YCSB_HOME/conf"
+if [ -z "$CLASSPATH" ] ; then
+  CLASSPATH="$YCSB_HOME/conf"
+else
+  CLASSPATH="$CLASSPATH:$YCSB_HOME/conf"
+fi
 
-# Deprecation messages
-case "$BINDING_DIR" in
-  cassandra2)
-    echo "[WARN] The 'cassandra2-cql' client has been deprecated. It has been renamed to simply 'cassandra-cql'. This alias will be removed in the next YCSB release." >&2
-    BINDING_DIR="cassandra"
-    ;;
-  hbase14)
-    echo "[WARN] The 'hbase14' client has been deprecated. HBase 1.y users should rely on the 'hbase1' client instead." >&2
-    BINDING_DIR="hbase1"
-    ;;
-  arangodb3)
-    echo "[WARN] The 'arangodb3' client has been deprecated. The binding 'arangodb' now covers every ArangoDB version. This alias will be removed in the next YCSB release." >&2
-    BINDING_DIR="arangodb"
-    ;;
-  couchbase)
-    echo "[WARN] The 'couchbase' client is deprecated. If you are using Couchbase 4.0+ try using the 'couchbase2' client instead." >&2
-    ;;
-esac
+# Cassandra2 deprecation message
+if [ "${BINDING_DIR}" = "cassandra2" ] ; then
+  echo "[WARN] The 'cassandra2-cql' client has been deprecated. It has been \
+renamed to simply 'cassandra-cql'. This alias will be removed  in the next \
+YCSB release."
+  BINDING_DIR="cassandra"
+fi
+
+# hbase14 replaced by hbas1
+if [ "${BINDING_DIR}" = "hbase14" ] ; then
+  echo "[WARN] The 'hbase14' client has been deprecated. HBase 1.y users should \
+rely on the 'hbase1' client instead."
+  BINDING_DIR="hbase1"
+fi
+
+# arangodb3 deprecation message
+if [ "${BINDING_DIR}" = "arangodb3" ] ; then
+  echo "[WARN] The 'arangodb3' client has been deprecated. The binding 'arangodb' \
+now covers every ArangoDB version. This alias will be removed \
+in the next YCSB release."
+  BINDING_DIR="arangodb"
+fi
 
 # Build classpath
-if "$DISTRIBUTION"; then
+#   The "if" check after the "for" is because glob may just return the pattern
+#   when no files are found.  The "if" makes sure the file is really there.
+if $DISTRIBUTION; then
   # Core libraries
-  for f in "$YCSB_HOME"/lib/*.jar; do
-    [ -r "$f" ] && CLASSPATH="$CLASSPATH:$f"
+  for f in "$YCSB_HOME"/lib/*.jar ; do
+    if [ -r "$f" ] ; then
+      CLASSPATH="$CLASSPATH:$f"
+    fi
   done
 
   # Database conf dir
-  [ -r "$YCSB_HOME/$BINDING_DIR-binding/conf" ] && CLASSPATH="$CLASSPATH:$YCSB_HOME/$BINDING_DIR-binding/conf"
+  if [ -r "$YCSB_HOME"/"$BINDING_DIR"-binding/conf ] ; then
+    CLASSPATH="$CLASSPATH:$YCSB_HOME/$BINDING_DIR-binding/conf"
+  fi
 
   # Database libraries
-  for f in "$YCSB_HOME/$BINDING_DIR-binding/lib/*.jar"; do
-    [ -r "$f" ] && CLASSPATH="$CLASSPATH:$f"
+  for f in "$YCSB_HOME"/"$BINDING_DIR"-binding/lib/*.jar ; do
+    if [ -r "$f" ] ; then
+      CLASSPATH="$CLASSPATH:$f"
+    fi
   done
+
+# Source checkout
 else
   # Check for some basic libraries to see if the source has been built.
-  if ! ls "$YCSB_HOME/core/target/"*.jar 1>/dev/null 2>&1 || \
-     ! ls "$YCSB_HOME/$BINDING_DIR/target/"*.jar 1>/dev/null 2>&1; then
+  if ! ls "$YCSB_HOME"/core/target/dependency/*.jar 1> /dev/null 2>&1 || \
+     ! ls "$YCSB_HOME"/"$BINDING_DIR"/target/*.jar 1>/dev/null 2>&1; then
     # Call mvn to build source checkout.
-    if [ "$BINDING_NAME" = "basic" ]; then
+    if [ "$BINDING_NAME" = "basic" ] ; then
       MVN_PROJECT=core
     else
       MVN_PROJECT="$BINDING_DIR"-binding
     fi
 
-    echo "[WARN] YCSB libraries not found. Attempting to build..." >&2
-    if ! mvn -Psource-run -pl "site.ycsb:$MVN_PROJECT" -am package -DskipTests; then
-      echo "[ERROR] Error trying to build project. Exiting." >&2
-      exit 1
+    echo "[WARN] YCSB libraries not found.  Attempting to build..."
+    if mvn -Psource-run -pl site.ycsb:"$MVN_PROJECT" -am package -DskipTests; then
+      echo "[ERROR] Error trying to build project. Exiting."
+      exit 1;
     fi
   fi
 
   # Core libraries
-  for f in "$YCSB_HOME/core/target/"*.jar; do
-    [ -r "$f" ] && CLASSPATH="$CLASSPATH:$f"
+  for f in "$YCSB_HOME"/core/target/*.jar ; do
+    if [ -r "$f" ] ; then
+      CLASSPATH="$CLASSPATH:$f"
+    fi
   done
 
   # Core dependency libraries
-  for f in "$YCSB_HOME/core/target/dependency/"*.jar; do
-    [ -r "$f" ] && CLASSPATH="$CLASSPATH:$f"
+  for f in "$YCSB_HOME"/core/target/dependency/*.jar ; do
+    if [ -r "$f" ] ; then
+      CLASSPATH="$CLASSPATH:$f"
+    else
+      echo "No JAR files found in dependency directory. Removing..."
+      rm -rf "$YCSB_HOME/core/target/dependency"
+      break
+    fi
   done
 
   # Database conf (need to find because location is not consistent)
-  CLASSPATH_CONF=$(find "$YCSB_HOME/$BINDING_DIR" -name "conf" | while IFS="" read -r file; do echo ":$file"; done)
-  [ -n "$CLASSPATH_CONF" ] && CLASSPATH="$CLASSPATH$CLASSPATH_CONF"
+  CLASSPATH_CONF=$(find "$YCSB_HOME"/$BINDING_DIR -name "conf" | while IFS="" read -r file; do echo ":$file"; done)
+  if [ "x$CLASSPATH_CONF" != "x" ]; then
+    CLASSPATH="$CLASSPATH$CLASSPATH_CONF"
+  fi
 
   # Database libraries
-  for f in "$YCSB_HOME/$BINDING_DIR/target/"*.jar; do
-    [ -r "$f" ] && CLASSPATH="$CLASSPATH:$f"
+  for f in "$YCSB_HOME"/"$BINDING_DIR"/target/*.jar ; do
+    if [ -r "$f" ] ; then
+      CLASSPATH="$CLASSPATH:$f"
+    fi
   done
 
   # Database dependency libraries
-  for f in "$YCSB_HOME/$BINDING_DIR/target/dependency/"*.jar; do
-    [ -r "$f" ] && CLASSPATH="$CLASSPATH:$f"
+  for f in "$YCSB_HOME"/"$BINDING_DIR"/target/dependency/*.jar ; do
+    if [ -r "$f" ] ; then
+      CLASSPATH="$CLASSPATH:$f"
+    fi
   done
 fi
 
+# Couchbase deprecation message
+if [ "${BINDING_DIR}" = "couchbase" ] ; then
+  echo "[WARN] The 'couchbase' client is deprecated. If you are using \
+Couchbase 4.0+ try using the 'couchbase2' client instead."
+fi
+
 # For Cygwin, switch paths to Windows format before running java
-if "$CYGWIN"; then
-  JAVA_HOME=$(cygpath --unix "$JAVA_HOME")
-  CLASSPATH=$(cygpath --path --windows "$CLASSPATH")
+if $CYGWIN; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=$(cygpath --unix "$JAVA_HOME")
+  [ -n "$CLASSPATH" ] && CLASSPATH=$(cygpath --path --windows "$CLASSPATH")
 fi
 
 # Get the rest of the arguments
-YCSB_ARGS="${@:3}"
+YCSB_ARGS=$(echo "$@" | cut -d' ' -f3-)
+
+# Check if log directory exists, if not create it
+if [ ! -d "$YCSB_HOME/workload-logs" ]; then
+  echo "Creating log directory..."
+  mkdir -p $YCSB_HOME/workload-logs
+fi
 
 # About to run YCSB
-echo "$JAVA_HOME/bin/java $JAVA_OPTS -classpath \"$CLASSPATH\" $YCSB_CLASS $YCSB_COMMAND -db $BINDING_CLASS $YCSB_ARGS"
+echo "$JAVA_HOME/bin/java $JAVA_OPTS -classpath $CLASSPATH $YCSB_CLASS $YCSB_COMMAND -db $BINDING_CLASS $YCSB_ARGS" | tee -a $YCSB_HOME/workload-logs/command-executor.log 2>&1
 
 # Run YCSB
-"$JAVA_HOME/bin/java" $JAVA_OPTS -classpath "$CLASSPATH" $YCSB_CLASS $YCSB_COMMAND -db "$BINDING_CLASS" "$YCSB_ARGS"
+# Shellcheck reports the following line as needing double quotes to prevent
+# globbing and word splitting.  However, word splitting is the desired effect
+# here.  So, the shellcheck error is disabled for this line.
+# shellcheck disable=SC2086
+"$JAVA_HOME/bin/java" $JAVA_OPTS -classpath "$CLASSPATH" $YCSB_CLASS $YCSB_COMMAND -db $BINDING_CLASS $YCSB_ARGS | tee -a $YCSB_HOME/workload-logs/command-executor.log 2>&1
+


### PR DESCRIPTION
This commit enhances the YCSB control script by integrating the 'tee' command to enable dual logging capabilities. Now, the script outputs logs to both the terminal and a log file located in 'YCSB_HOME/workload-logs/command-executor.log'. This change aids in real-time monitoring while preserving a historical record of the script's output for future analysis. Additionally, a check has been added to ensure the log directory exists before attempting to write logs, enhancing the script's robustness.